### PR TITLE
[IT-1046] Remove `sam publish` from deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,4 @@ jobs:
           pipenv run sam package --template-file .aws-sam/build/template.yaml \
             --s3-bucket $LAMBDA_BUCKET \
             --output-template-file .aws-sam/build/$REPO_NAME.yaml
-        - pipenv run sam publish --template .aws-sam/build/$REPO_NAME.yaml
         - pipenv run aws s3 cp .aws-sam/build/$REPO_NAME.yaml s3://$CFN_BUCKET/$REPO_NAME/$TRAVIS_BRANCH/


### PR DESCRIPTION
The lambda function is uploaded to S3 during `sam package` and
we manually copy the built SAM template to S3, so `sam publish`
is not necessary in our use case. Remove it since it is failing
on missing metadata.