### PR TITLE
[IT-1046] Fix SourceArn typo

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -65,7 +65,7 @@ Resources:
       Action: 'lambda:InvokeFunction'
       FunctionName: !GetAtt CostReportFunction.Arn
       Principal: 's3.amazonaws.com'
-      SourceArn: !Sub "arn:aws:s3:::${bucketName}/*"
+      SourceArn: !Sub "arn:aws:s3:::${bucketName}"
       SourceAccount: !Ref 'AWS::AccountId'
 
 


### PR DESCRIPTION
The permission SourceArn should not have anything after the bucket name.
